### PR TITLE
Move definition of Source out of weather entity

### DIFF
--- a/owm-adapter-api/src/main/java/com/scottlogic/weather/owmadapter/api/message/Wind.java
+++ b/owm-adapter-api/src/main/java/com/scottlogic/weather/owmadapter/api/message/Wind.java
@@ -15,9 +15,10 @@ public class Wind {
 	private final short fromDegrees;
 
 	public Wind(final BigDecimal speed, final short fromDegrees) {
+		// Yes, OWM sometimes sends 360 degrees:
 		checkState(
-				fromDegrees >= 0 && fromDegrees < 360,
-				"fromDegrees must be between 0 and 359 degrees"
+				fromDegrees >= 0 && fromDegrees <= 360,
+				"fromDegrees should be between 0 and 360, but received [" + fromDegrees + "]"
 		);
 
 		this.speed = speed;

--- a/weather-service-api/src/main/java/com/scottlogic/weather/weatherservice/api/message/Wind.java
+++ b/weather-service-api/src/main/java/com/scottlogic/weather/weatherservice/api/message/Wind.java
@@ -19,9 +19,10 @@ public class Wind {
 	private final short fromDegrees;
 
 	public Wind(final BigDecimal speed, final short fromDegrees) {
+		// Yes, OWM sometimes sends 360 degrees:
 		checkState(
-				fromDegrees >= 0 && fromDegrees < 360,
-				"fromDegrees must be between 0 and 359 degrees"
+				fromDegrees >= 0 && fromDegrees <= 360,
+				"fromDegrees should be between 0 and 360, but received [" + fromDegrees + "]"
 		);
 
 		this.speed = speed;

--- a/weather-service-api/src/main/java/com/scottlogic/weather/weatherservice/api/message/internal/WeatherStreamParameters.java
+++ b/weather-service-api/src/main/java/com/scottlogic/weather/weatherservice/api/message/internal/WeatherStreamParameters.java
@@ -1,0 +1,20 @@
+package com.scottlogic.weather.weatherservice.api.message.internal;
+
+import com.lightbend.lagom.serialization.Jsonable;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Singular;
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+@Builder
+public class WeatherStreamParameters implements Jsonable {
+
+	short emitFrequencySeconds;
+
+	@Singular
+	@NonNull
+	List<String> locations;
+}

--- a/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/SourceGenerator.java
+++ b/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/SourceGenerator.java
@@ -1,0 +1,57 @@
+package com.scottlogic.weather.weatherservice.impl;
+
+import akka.stream.javadsl.Source;
+import com.google.inject.Inject;
+import com.scottlogic.weather.owmadapter.api.OwmAdapter;
+import com.scottlogic.weather.weatherservice.api.message.WeatherDataResponse;
+import com.scottlogic.weather.weatherservice.impl.entity.WeatherCommand;
+import com.scottlogic.weather.weatherservice.impl.entity.WeatherEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.CompletionStage;
+
+public class SourceGenerator {
+
+	private final Logger log = LoggerFactory.getLogger(getClass());
+
+	private final OwmAdapter owmAdapter;
+	private final PersistentEntityRegistryFacade persistentEntityRegistryFacade;
+
+	@Inject
+	public SourceGenerator(final OwmAdapter owmAdapter, final PersistentEntityRegistryFacade persistentEntityRegistryFacade) {
+		this.owmAdapter = owmAdapter;
+		this.persistentEntityRegistryFacade = persistentEntityRegistryFacade;
+		persistentEntityRegistryFacade.register(WeatherEntity.class);
+	}
+
+	public CompletionStage<Source<WeatherDataResponse, ?>> getSourceOfCurrentWeatherData(final String entityId) {
+		return this.persistentEntityRegistryFacade.sendCommandToPersistentEntity(
+				WeatherEntity.class,
+				entityId,
+				new WeatherCommand.GetWeatherStreamParameters()
+		).thenApply(weatherStreamParameters ->
+				Source.cycle(() -> weatherStreamParameters.getLocations().iterator())
+						.mapAsync(3, this::getCurrentWeatherForLocation)
+						.throttle(1, Duration.of(weatherStreamParameters.getEmitFrequencySeconds(), ChronoUnit.SECONDS))
+						.watchTermination((source, future) -> {
+							future.whenComplete((done, throwable) -> {
+								if (throwable != null) {
+									log.error("Stream of weather data terminated with error", throwable);
+								} else {
+									log.info("Stream of weather data closed following successful completion");
+								}
+							});
+							return source;
+						})
+		);
+	}
+
+	private CompletionStage<WeatherDataResponse> getCurrentWeatherForLocation(final String location) {
+		return this.owmAdapter
+				.getCurrentWeather(location).invoke()
+				.thenApply(MessageUtils::transformWeatherData);
+	}
+}

--- a/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/entity/WeatherCommand.java
+++ b/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/entity/WeatherCommand.java
@@ -1,13 +1,15 @@
 package com.scottlogic.weather.weatherservice.impl.entity;
 
-import akka.stream.javadsl.Source;
 import com.lightbend.lagom.javadsl.persistence.PersistentEntity;
 import com.lightbend.lagom.serialization.Jsonable;
-import com.scottlogic.weather.weatherservice.api.message.WeatherDataResponse;
+import com.scottlogic.weather.weatherservice.api.message.internal.WeatherStreamParameters;
+import lombok.Value;
 
 public interface WeatherCommand extends Jsonable {
 
-	class GetCurrentWeatherStream implements WeatherCommand, PersistentEntity.ReplyType<Source<WeatherDataResponse, ?>> {
+	@Value
+	class GetWeatherStreamParameters implements WeatherCommand, PersistentEntity.ReplyType<WeatherStreamParameters> {
 		// This is a read-only command, with no parameters.
 	}
+
 }

--- a/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/entity/WeatherEntity.java
+++ b/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/entity/WeatherEntity.java
@@ -1,26 +1,19 @@
 package com.scottlogic.weather.weatherservice.impl.entity;
 
-import akka.stream.javadsl.Source;
-import com.google.inject.Inject;
 import com.lightbend.lagom.javadsl.persistence.PersistentEntity;
-import com.scottlogic.weather.owmadapter.api.OwmAdapter;
-import com.scottlogic.weather.weatherservice.api.message.WeatherDataResponse;
-import com.scottlogic.weather.weatherservice.impl.MessageUtils;
-import com.scottlogic.weather.weatherservice.impl.entity.WeatherCommand.GetCurrentWeatherStream;
+import com.scottlogic.weather.weatherservice.api.message.internal.WeatherStreamParameters;
+import com.scottlogic.weather.weatherservice.impl.entity.WeatherCommand.GetWeatherStreamParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Optional;
-import java.util.concurrent.CompletionStage;
 
 /**
  * This is an event sourced entity. It has a state, {@link WeatherState}, which stores the current
  * list of weather locations and stream push frequency.
  * <p>
  * Event sourced entities are interacted with by sending them commands. This entity currently
- * supports one read-only command: {@link GetCurrentWeatherStream}.
+ * supports one read-only command: {@link GetWeatherStreamParameters}.
  * </p>
  * <p>
  * Commands that are not read-only are translated to events, which are then persisted by the entity.
@@ -36,13 +29,6 @@ public class WeatherEntity extends PersistentEntity<WeatherCommand, WeatherEvent
 
 	private final Logger log = LoggerFactory.getLogger(this.getClass());
 
-	private final OwmAdapter owmAdapter;
-
-	@Inject
-	public WeatherEntity(final OwmAdapter owmAdapter) {
-		this.owmAdapter = owmAdapter;
-	}
-
 	/**
 	 * An entity can define different behaviours for different states, but it will
 	 * always start with an initial behaviour. This entity only has one behaviour.
@@ -53,32 +39,18 @@ public class WeatherEntity extends PersistentEntity<WeatherCommand, WeatherEvent
 				snapshotState.orElse(WeatherState.INITIAL_STATE)
 		);
 
-		b.setReadOnlyCommandHandler(GetCurrentWeatherStream.class, (cmd, ctx) -> {
-			log.info("Received command to get a stream of weather data");
-			ctx.reply(this.getSourceOfCurrentWeatherData());
+		b.setReadOnlyCommandHandler(GetWeatherStreamParameters.class, (cmd, ctx) -> {
+			log.info("Received command to get weather stream parameters");
+
+			ctx.reply(
+					WeatherStreamParameters.builder()
+							.emitFrequencySeconds(state().getEmitFrequencySecs())
+							.locations(state().getLocations())
+							.build()
+			);
 		});
 
 		return b.build();
 	}
 
-	private Source<WeatherDataResponse, ?> getSourceOfCurrentWeatherData() {
-		return Source.cycle(() -> state().getLocations().iterator())
-				.mapAsync(3, this::getCurrentWeatherForLocation)
-				.throttle(1, Duration.of(state().getEmitFrequencySecs(), ChronoUnit.SECONDS))
-				.watchTermination((source, future) -> {
-					future.whenComplete((done, throwable) -> {
-						if (throwable != null) {
-							log.error("Stream of weather data terminated with error", throwable);
-						} else {
-							log.info("Stream of weather data closed following successful completion");
-						}
-					});
-					return source;
-				});
-	}
-
-	private CompletionStage<WeatherDataResponse> getCurrentWeatherForLocation(final String location) {
-		return this.owmAdapter.getCurrentWeather(location).invoke()
-				.thenApply(MessageUtils::transformWeatherData);
-	}
 }

--- a/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/SourceGeneratorTest.java
+++ b/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/SourceGeneratorTest.java
@@ -1,0 +1,105 @@
+package com.scottlogic.weather.weatherservice.impl;
+
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.testkit.TestSubscriber.Probe;
+import akka.stream.testkit.javadsl.TestSink;
+import akka.testkit.javadsl.TestKit;
+import com.google.common.collect.ImmutableList;
+import com.scottlogic.weather.weatherservice.api.message.WeatherDataResponse;
+import com.scottlogic.weather.weatherservice.api.message.internal.WeatherStreamParameters;
+import com.scottlogic.weather.weatherservice.impl.entity.WeatherCommand.GetWeatherStreamParameters;
+import com.scottlogic.weather.weatherservice.impl.entity.WeatherEntity;
+import com.scottlogic.weather.weatherservice.impl.stub.OwmAdapterStub;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+class SourceGeneratorTest {
+
+	private static ActorSystem system;
+	private static Materializer materializer;
+
+	private final Logger log = LoggerFactory.getLogger(getClass());
+	private final String entityId = "default";
+
+	@Mock private PersistentEntityRegistryFacade registryFacade;
+
+	private SourceGenerator sut;
+
+	@BeforeAll
+	static void setup() {
+		system = ActorSystem.create("WeatherEntityTest");
+		materializer = ActorMaterializer.create(system);
+	}
+
+	@AfterAll
+	static void teardown() {
+		TestKit.shutdownActorSystem(system);
+		system = null;
+	}
+	@BeforeEach
+	void beforeEach() {
+		initMocks(this);
+		sut = new SourceGenerator(new OwmAdapterStub(), registryFacade);
+	}
+
+	@Test
+	void getSourceOfCurrentWeatherData_ReturnsStreamOfDataForLocationsInEntityState() {
+		final short emitFrequency = 2;
+		final List<String> locations = ImmutableList.of("London, UK", "Paris, FR", "New York, US");
+
+		when(registryFacade.sendCommandToPersistentEntity(
+				eq(WeatherEntity.class),
+				eq(entityId),
+				any(GetWeatherStreamParameters.class)
+		)).thenReturn(
+				CompletableFuture.completedFuture(
+						WeatherStreamParameters.builder()
+								.emitFrequencySeconds(emitFrequency)
+								.locations(locations)
+								.build()
+				)
+		);
+
+		sut.getSourceOfCurrentWeatherData(entityId)
+				.thenAccept(source -> {
+					final FiniteDuration safeDuration = FiniteDuration.apply(emitFrequency + 1, TimeUnit.SECONDS);
+					final Probe<WeatherDataResponse> probe = source.runWith(TestSink.probe(system), materializer);
+					probe.request(4);
+
+					final WeatherDataResponse elementOne = probe.expectNext(safeDuration);
+					log.info("Stream emitted " + elementOne);
+					final WeatherDataResponse elementTwo = probe.expectNext(safeDuration);
+					log.info("Stream emitted " + elementTwo);
+					final WeatherDataResponse elementThree = probe.expectNext(safeDuration);
+					log.info("Stream emitted " + elementThree);
+					final WeatherDataResponse elementFour = probe.expectNext(safeDuration);
+					log.info("Stream emitted " + elementFour);
+					probe.cancel();
+
+					assertThat(elementOne.getLocation(), is(locations.get(0)));
+					assertThat(elementTwo.getLocation(), is(locations.get(1)));
+					assertThat(elementThree.getLocation(), is(locations.get(2)));
+					assertThat(elementFour.getLocation(), is(locations.get(0)));
+
+				});
+	}
+}

--- a/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/entity/WeatherEntityTest.java
+++ b/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/entity/WeatherEntityTest.java
@@ -1,97 +1,58 @@
 package com.scottlogic.weather.weatherservice.impl.entity;
 
 import akka.actor.ActorSystem;
-import akka.stream.Materializer;
-import akka.stream.javadsl.Source;
-import akka.stream.testkit.TestSubscriber.Probe;
-import akka.stream.testkit.javadsl.TestSink;
 import akka.testkit.javadsl.TestKit;
 import com.lightbend.lagom.javadsl.testkit.PersistentEntityTestDriver;
 import com.lightbend.lagom.javadsl.testkit.PersistentEntityTestDriver.Outcome;
-import com.scottlogic.weather.owmadapter.api.OwmAdapter;
-import com.scottlogic.weather.weatherservice.api.message.WeatherDataResponse;
-import com.scottlogic.weather.weatherservice.impl.entity.WeatherCommand.GetCurrentWeatherStream;
+import com.scottlogic.weather.weatherservice.api.message.internal.WeatherStreamParameters;
+import com.scottlogic.weather.weatherservice.impl.entity.WeatherCommand.GetWeatherStreamParameters;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import play.api.libs.concurrent.MaterializerProvider;
-import scala.concurrent.duration.FiniteDuration;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 @DisplayName("Tests for the persistent entity storing weather stream parameters")
 class WeatherEntityTest {
 	private static ActorSystem system;
-	private static Materializer materializer;
-
-	@Mock
-	private OwmAdapter owmAdapter;
 
 	private PersistentEntityTestDriver<WeatherCommand, WeatherEvent, WeatherState> testDriver;
 
 	@BeforeAll
 	static void setup() {
 		system = ActorSystem.create("WeatherEntityTest");
-		materializer = new MaterializerProvider(system).get();
 	}
 
 	@AfterAll
 	static void teardown() {
 		TestKit.shutdownActorSystem(system);
 		system = null;
-		materializer = null;
 	}
 
 	@BeforeEach
 	void beforeEach() {
-		initMocks(this);
-		testDriver = new PersistentEntityTestDriver<>(system, new WeatherEntity(owmAdapter), "default");
+		testDriver = new PersistentEntityTestDriver<>(system, new WeatherEntity(), "default");
 	}
 
-	@Disabled(
-			"This is broken because akka Source is not serializable. The implementation is also " +
-			"broken in a cluster, because if the request arrived at a different instance to the " +
-			"one in which the entity is located, then the reply containing the source would need " +
-			"to be serialized for sending back to the original instance. " +
-			"We need to rethink this approach... Probably it would be better for a dedicated " +
-			"stream generator class to query the entity for its current state when creating a " +
-			"stream, and subscribe to events that change the state. The entity would then not " +
-			"need to know about our adapter service(s), and its job of persisting state would be " +
-			"far clearer."
-	)
 	@Test
-	void commandGetCurrentWeatherStream_PersistsZeroEventsAndReturnsASource() {
-		final List<String> locations = testDriver.initialize(Optional.empty()).state().getLocations();
-		final Outcome<WeatherEvent, WeatherState> result = testDriver.run(new GetCurrentWeatherStream());
+	void commandGetWeatherStreamParameters_ReturnsValuesFromCurrentState() {
+		final WeatherState initialState = testDriver.initialize(Optional.empty()).state();
 
-		assertThat(result.issues(), is(empty()));
-		assertThat(result.events(), is(empty()));
-		assertThat(result.getReplies(), hasSize(1));
+		final Outcome<WeatherEvent, WeatherState> outcomeOne = testDriver.run(new GetWeatherStreamParameters());
+		assertThat(outcomeOne.issues(), is(empty()));
+		assertThat(outcomeOne.events(), is(empty()));
+		assertThat(outcomeOne.getReplies(), hasSize(1));
 
-		final Source<WeatherDataResponse, ?> source = (Source<WeatherDataResponse, ?>) result.getReplies().get(0);
-		final Probe<WeatherDataResponse> probe = source.runWith(TestSink.probe(system), materializer);
-
-		probe.request(3);
-		final WeatherDataResponse responseOne = probe.expectNext(FiniteDuration.apply(4, TimeUnit.SECONDS));
-		final WeatherDataResponse responseTwo = probe.expectNext(FiniteDuration.apply(4, TimeUnit.SECONDS));
-		final WeatherDataResponse responseThree = probe.expectNext(FiniteDuration.apply(4, TimeUnit.SECONDS));
-		probe.cancel();
-
-		assertThat(responseOne.getLocation(), is(locations.get(0)));
-		assertThat(responseTwo.getLocation(), is(locations.get(1)));
-		assertThat(responseThree.getLocation(), is(locations.get(2)));
+		final WeatherStreamParameters replyOne = (WeatherStreamParameters) outcomeOne.getReplies().get(0);
+		assertThat(replyOne.getEmitFrequencySeconds(), is(initialState.getEmitFrequencySecs()));
+		assertThat(replyOne.getLocations(), is(initialState.getLocations()));
 	}
 
 }


### PR DESCRIPTION
WeatherEntity is now much smaller, and responsibility of providing a Source is handled by a dedicated class, `SourceGenerator`. In future, that class can listen for events that update the state and reconstruct the Source on-demand.