### PR TITLE
Flow shenanigans for better weather streaming

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ lazy val `weather-service-impl` = (project in file("weather-service-impl"))
   .settings(
     common,
     libraryDependencies ++= commonImplDeps,
+    libraryDependencies += lagomJavadslPubSub,
     testOptions += Tests.Argument(jupiterTestFramework, "-a", "-v")
   )
   .settings(lagomForkedTestSettings: _*)

--- a/weather-service-api/src/main/java/com/scottlogic/weather/weatherservice/api/message/StreamParametersUpdated.java
+++ b/weather-service-api/src/main/java/com/scottlogic/weather/weatherservice/api/message/StreamParametersUpdated.java
@@ -1,0 +1,19 @@
+package com.scottlogic.weather.weatherservice.api.message;
+
+import com.lightbend.lagom.serialization.CompressedJsonable;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Singular;
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+@Builder
+public class StreamParametersUpdated implements CompressedJsonable {
+	int emitFrequencySecs;
+
+	@NonNull
+	@Singular
+	List<String> locations;
+}

--- a/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/PubSubRegistryFacade.java
+++ b/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/PubSubRegistryFacade.java
@@ -1,0 +1,33 @@
+package com.scottlogic.weather.weatherservice.impl;
+
+import akka.NotUsed;
+import akka.stream.javadsl.Source;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.lightbend.lagom.javadsl.pubsub.PubSubRegistry;
+import com.lightbend.lagom.javadsl.pubsub.TopicId;
+
+import java.util.Optional;
+
+@Singleton
+public class PubSubRegistryFacade {
+
+	private final PubSubRegistry pubSubRegistry;
+
+	@Inject
+	public PubSubRegistryFacade(final PubSubRegistry pubSubRegistry) {
+		this.pubSubRegistry = pubSubRegistry;
+	}
+
+	public <T> void publish(final Class<T> messageClass, final T message, final Optional<String> topicSuffix) {
+		this.pubSubRegistry.refFor(
+				TopicId.of(messageClass, topicSuffix.orElse(""))
+		).publish(message);
+	}
+
+	public <T> Source<T, NotUsed> subscribe(final Class<T> messageClass, final Optional<String> topicSuffix) {
+		return this.pubSubRegistry.refFor(
+				TopicId.of(messageClass, topicSuffix.orElse(""))
+		).subscriber();
+	}
+}

--- a/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/StreamGeneratorFactory.java
+++ b/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/StreamGeneratorFactory.java
@@ -1,8 +1,9 @@
 package com.scottlogic.weather.weatherservice.impl;
 
-import akka.actor.ActorSystem;
+import akka.stream.Materializer;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.lightbend.lagom.javadsl.pubsub.PubSubRegistry;
 import com.scottlogic.weather.owmadapter.api.OwmAdapter;
 
 @Singleton
@@ -10,18 +11,23 @@ public class StreamGeneratorFactory {
 
 	private final OwmAdapter owmAdapter;
 	private final PersistentEntityRegistryFacade registryFacade;
-	private final ActorSystem actorSystem;
+	private final Materializer materializer;
+	private final PubSubRegistry pubSubRegistry;
 
 	@Inject
 	public StreamGeneratorFactory(
-			final OwmAdapter owmAdapter, final PersistentEntityRegistryFacade registryFacade, final ActorSystem actorSystem
-	) {
+			final OwmAdapter owmAdapter,
+			final PersistentEntityRegistryFacade registryFacade,
+			final Materializer materializer,
+			final PubSubRegistry pubSubRegistry
+			) {
 		this.owmAdapter = owmAdapter;
 		this.registryFacade = registryFacade;
-		this.actorSystem = actorSystem;
+		this.materializer = materializer;
+		this.pubSubRegistry = pubSubRegistry;
 	}
 
-	public StreamGenerator get() {
-		return new StreamGenerator(owmAdapter, registryFacade, actorSystem);
+	public StreamGenerator get(final String entityId) {
+		return new StreamGenerator(owmAdapter, registryFacade, materializer, pubSubRegistry, entityId);
 	}
 }

--- a/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/StreamGeneratorFactory.java
+++ b/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/StreamGeneratorFactory.java
@@ -3,31 +3,30 @@ package com.scottlogic.weather.weatherservice.impl;
 import akka.stream.Materializer;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.lightbend.lagom.javadsl.pubsub.PubSubRegistry;
 import com.scottlogic.weather.owmadapter.api.OwmAdapter;
 
 @Singleton
 public class StreamGeneratorFactory {
 
 	private final OwmAdapter owmAdapter;
-	private final PersistentEntityRegistryFacade registryFacade;
+	private final PersistentEntityRegistryFacade persistentEntityRegistryFacade;
+	private final PubSubRegistryFacade pubSubRegistryFacade;
 	private final Materializer materializer;
-	private final PubSubRegistry pubSubRegistry;
 
 	@Inject
 	public StreamGeneratorFactory(
 			final OwmAdapter owmAdapter,
-			final PersistentEntityRegistryFacade registryFacade,
-			final Materializer materializer,
-			final PubSubRegistry pubSubRegistry
-			) {
+			final PersistentEntityRegistryFacade persistentEntityRegistryFacade,
+			PubSubRegistryFacade pubSubRegistryFacade,
+			final Materializer materializer
+	) {
 		this.owmAdapter = owmAdapter;
-		this.registryFacade = registryFacade;
+		this.persistentEntityRegistryFacade = persistentEntityRegistryFacade;
+		this.pubSubRegistryFacade = pubSubRegistryFacade;
 		this.materializer = materializer;
-		this.pubSubRegistry = pubSubRegistry;
 	}
 
 	public StreamGenerator get(final String entityId) {
-		return new StreamGenerator(owmAdapter, registryFacade, materializer, pubSubRegistry, entityId);
+		return new StreamGenerator(owmAdapter, persistentEntityRegistryFacade, pubSubRegistryFacade, materializer, entityId);
 	}
 }

--- a/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/WeatherServiceImpl.java
+++ b/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/WeatherServiceImpl.java
@@ -63,7 +63,7 @@ public class WeatherServiceImpl implements WeatherService {
 	public ServiceCall<NotUsed, Source<WeatherDataResponse, ?>> currentWeatherStream() {
 		return request -> {
 			log.info("Received request for stream of current weather");
-			return CompletableFuture.completedFuture(this.streamGeneratorFactory.get().getSourceOfCurrentWeatherData(entityId));
+			return CompletableFuture.completedFuture(this.streamGeneratorFactory.get(entityId).getSourceOfCurrentWeatherData());
 		};
 	}
 

--- a/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/StreamGeneratorTest.java
+++ b/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/StreamGeneratorTest.java
@@ -2,20 +2,19 @@ package com.scottlogic.weather.weatherservice.impl;
 
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
+import akka.stream.DelayOverflowStrategy;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Source;
-import akka.stream.testkit.TestSubscriber.Probe;
+import akka.stream.testkit.TestSubscriber;
 import akka.stream.testkit.javadsl.TestSink;
 import akka.testkit.javadsl.TestKit;
 import com.google.common.collect.ImmutableList;
-import com.lightbend.lagom.internal.javadsl.pubsub.PubSubRegistryImpl;
-import com.lightbend.lagom.javadsl.pubsub.PubSubRegistry;
+import com.scottlogic.weather.weatherservice.api.message.StreamParametersUpdated;
 import com.scottlogic.weather.weatherservice.api.message.WeatherDataResponse;
 import com.scottlogic.weather.weatherservice.api.message.WeatherStreamParameters;
 import com.scottlogic.weather.weatherservice.impl.entity.WeatherCommand.GetWeatherStreamParameters;
 import com.scottlogic.weather.weatherservice.impl.entity.WeatherEntity;
 import com.scottlogic.weather.weatherservice.impl.stub.OwmAdapterStub;
-import com.typesafe.config.ConfigFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +24,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.concurrent.duration.FiniteDuration;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -33,6 +35,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -40,12 +43,12 @@ class StreamGeneratorTest {
 
 	private static ActorSystem system;
 	private static Materializer materializer;
-	private static PubSubRegistry pubSubRegistry;
 
 	private final Logger log = LoggerFactory.getLogger(getClass());
 	private final String entityId = "default";
 
-	@Mock private PersistentEntityRegistryFacade registryFacade;
+	@Mock private PersistentEntityRegistryFacade persistentEntityRegistryFacade;
+	@Mock private PubSubRegistryFacade pubSubRegistryFacade;
 
 	private StreamGenerator sut;
 
@@ -53,13 +56,11 @@ class StreamGeneratorTest {
 	static void setup() {
 		system = ActorSystem.create("StreamGeneratorTest");
 		materializer = ActorMaterializer.create(system);
-		pubSubRegistry = new PubSubRegistryImpl(system, ConfigFactory.parseString("subscriber-buffer-size: 2"));
 	}
 
 	@AfterAll
 	static void teardown() {
 		TestKit.shutdownActorSystem(system);
-		pubSubRegistry = null;
 		materializer = null;
 		system = null;
 	}
@@ -67,7 +68,13 @@ class StreamGeneratorTest {
 	@BeforeEach
 	void beforeEach() {
 		initMocks(this);
-		sut = new StreamGenerator(new OwmAdapterStub(), registryFacade, materializer, pubSubRegistry, entityId);
+		sut = new StreamGenerator(
+				new OwmAdapterStub(),
+				persistentEntityRegistryFacade,
+				pubSubRegistryFacade,
+				materializer,
+				entityId
+		);
 	}
 
 	@Test
@@ -76,7 +83,7 @@ class StreamGeneratorTest {
 		final List<String> locations = ImmutableList.of("London, UK", "Paris, FR", "New York, US");
 		final FiniteDuration safeDuration = FiniteDuration.apply(emitFrequency + 1, TimeUnit.SECONDS);
 
-		when(registryFacade.sendCommandToPersistentEntity(
+		when(persistentEntityRegistryFacade.sendCommandToPersistentEntity(
 				eq(WeatherEntity.class),
 				eq(entityId),
 				any(GetWeatherStreamParameters.class)
@@ -89,8 +96,14 @@ class StreamGeneratorTest {
 				)
 		);
 
+		doReturn(Source.maybe())
+				.when(pubSubRegistryFacade).subscribe(
+						StreamParametersUpdated.class,
+						Optional.of(entityId)
+				);
+
 		final Source<WeatherDataResponse, ?> source = sut.getSourceOfCurrentWeatherData();
-		final Probe<WeatherDataResponse> probe = source.runWith(TestSink.probe(system), materializer);
+		final TestSubscriber.Probe<WeatherDataResponse> probe = source.runWith(TestSink.probe(system), materializer);
 		probe.request(4);
 
 		final WeatherDataResponse elementOne = probe.expectNext(safeDuration);
@@ -107,5 +120,63 @@ class StreamGeneratorTest {
 		assertThat(elementTwo.getLocation(), is(locations.get(1)));
 		assertThat(elementThree.getLocation(), is(locations.get(2)));
 		assertThat(elementFour.getLocation(), is(locations.get(0)));
+	}
+
+	@Test
+	void getSourceOfCurrentWeatherData_StreamParametersUpdated_RestartsStreamOfWeatherData() {
+		final int originalEmitFrequency = 2;
+		final List<String> originalLocations = ImmutableList.of("London, UK", "Paris, FR", "New York, US");
+		final FiniteDuration originalSafeDuration = FiniteDuration.apply(originalEmitFrequency + 1, TimeUnit.SECONDS);
+		final int newEmitFrequency = 1;
+		final List<String> newLocations = ImmutableList.of("Helsinki, FI", "Stockholm, SE");
+		final FiniteDuration newSafeDuration = FiniteDuration.apply(newEmitFrequency + 1, TimeUnit.SECONDS);
+
+		final Source<StreamParametersUpdated, ?> parameterChangesSource = Source.single(
+				StreamParametersUpdated.builder()
+						.emitFrequencySecs(newEmitFrequency)
+						.locations(newLocations)
+						.build()
+		).delay(Duration.of(1, ChronoUnit.SECONDS), DelayOverflowStrategy.backpressure());
+
+		when(persistentEntityRegistryFacade.sendCommandToPersistentEntity(
+				eq(WeatherEntity.class),
+				eq(entityId),
+				any(GetWeatherStreamParameters.class)
+		)).thenReturn(
+				CompletableFuture.completedFuture(
+						WeatherStreamParameters.builder()
+								.emitFrequencySeconds(originalEmitFrequency)
+								.locations(originalLocations)
+								.build()
+				)
+		);
+
+		doReturn(parameterChangesSource)
+				.when(pubSubRegistryFacade).subscribe(
+				StreamParametersUpdated.class,
+				Optional.of(entityId)
+		);
+
+		final TestSubscriber.Probe<WeatherDataResponse> probe = sut.getSourceOfCurrentWeatherData()
+				.runWith(TestSink.probe(system), materializer);
+		probe.request(4);
+
+		// Fetch one element ...
+		final WeatherDataResponse elementOne = probe.expectNext(originalSafeDuration);
+		log.info("Stream emitted " + elementOne);
+
+		// ... and expect the (delayed) StreamParameterChanges message to have caused the stream to restart.
+		final WeatherDataResponse elementTwo = probe.expectNext(newSafeDuration);
+		log.info("Stream emitted " + elementTwo);
+		final WeatherDataResponse elementThree = probe.expectNext(newSafeDuration);
+		log.info("Stream emitted " + elementThree);
+		final WeatherDataResponse elementFour = probe.expectNext(newSafeDuration);
+		log.info("Stream emitted " + elementFour);
+		probe.cancel();
+
+		assertThat(elementOne.getLocation(), is(originalLocations.get(0)));
+		assertThat(elementTwo.getLocation(), is(newLocations.get(0)));
+		assertThat(elementThree.getLocation(), is(newLocations.get(1)));
+		assertThat(elementFour.getLocation(), is(newLocations.get(0)));
 	}
 }

--- a/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/WeatherServiceTest.java
+++ b/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/WeatherServiceTest.java
@@ -47,7 +47,7 @@ class WeatherServiceTest {
 	@BeforeEach
 	void beforeEach() {
 		initMocks(this);
-		when(streamGeneratorFactory.get()).thenReturn(streamGenerator);
+		when(streamGeneratorFactory.get(entityId)).thenReturn(streamGenerator);
 		sut = new WeatherServiceImpl(new OwmAdapterStub(), streamGeneratorFactory, registryFacade);
 	}
 
@@ -76,7 +76,7 @@ class WeatherServiceTest {
 	@Test
 	void currentWeatherStream_InvokesSourceGeneratorAndGetsBackASource() throws Exception {
 		sut.currentWeatherStream().invoke().toCompletableFuture().get(5, SECONDS);
-		verify(streamGenerator).getSourceOfCurrentWeatherData(entityId);
+		verify(streamGenerator).getSourceOfCurrentWeatherData();
 	}
 
 	@Test

--- a/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/entity/WeatherEntityTest.java
+++ b/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/entity/WeatherEntityTest.java
@@ -2,20 +2,13 @@ package com.scottlogic.weather.weatherservice.impl.entity;
 
 import akka.Done;
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
-import akka.stream.testkit.TestSubscriber.Probe;
-import akka.stream.testkit.javadsl.TestSink;
 import akka.testkit.javadsl.TestKit;
 import com.google.common.collect.ImmutableList;
-import com.lightbend.lagom.internal.javadsl.pubsub.PubSubRegistryImpl;
-import com.lightbend.lagom.javadsl.pubsub.PubSubRef;
-import com.lightbend.lagom.javadsl.pubsub.PubSubRegistry;
-import com.lightbend.lagom.javadsl.pubsub.TopicId;
 import com.lightbend.lagom.javadsl.testkit.PersistentEntityTestDriver;
 import com.lightbend.lagom.javadsl.testkit.PersistentEntityTestDriver.Outcome;
 import com.scottlogic.weather.weatherservice.api.message.StreamParametersUpdated;
 import com.scottlogic.weather.weatherservice.api.message.WeatherStreamParameters;
+import com.scottlogic.weather.weatherservice.impl.PubSubRegistryFacade;
 import com.scottlogic.weather.weatherservice.impl.entity.WeatherCommand.AddLocation;
 import com.scottlogic.weather.weatherservice.impl.entity.WeatherCommand.ChangeEmitFrequency;
 import com.scottlogic.weather.weatherservice.impl.entity.WeatherCommand.GetWeatherStreamParameters;
@@ -23,19 +16,17 @@ import com.scottlogic.weather.weatherservice.impl.entity.WeatherCommand.RemoveLo
 import com.scottlogic.weather.weatherservice.impl.entity.WeatherEvent.EmitFrequencyChanged;
 import com.scottlogic.weather.weatherservice.impl.entity.WeatherEvent.LocationAdded;
 import com.scottlogic.weather.weatherservice.impl.entity.WeatherEvent.LocationRemoved;
-import com.typesafe.config.ConfigFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import scala.concurrent.duration.Duration;
+import org.mockito.Mock;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
-import java.util.concurrent.TimeUnit;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,36 +34,33 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @DisplayName("Tests for the persistent entity storing weather stream parameters")
 class WeatherEntityTest {
 	private static ActorSystem system;
-	private static Materializer materializer;
-	private static PubSubRegistry pubSubRegistry;
 
 	private final String entityId = "default";
+	@Mock private PubSubRegistryFacade pubSubRegistryFacade;
 	private PersistentEntityTestDriver<WeatherCommand, WeatherEvent, WeatherState> testDriver;
 
 	@BeforeAll
 	static void setup() {
 		system = ActorSystem.create("WeatherEntityTest");
-		materializer = ActorMaterializer.create(system);
-		pubSubRegistry = new PubSubRegistryImpl(system, ConfigFactory.parseString("subscriber-buffer-size: 2"));
 	}
 
 	@AfterAll
 	static void teardown() {
 		TestKit.shutdownActorSystem(system);
-		pubSubRegistry = null;
-		materializer = null;
 		system = null;
 	}
 
 	@BeforeEach
 	void beforeEach() {
 		initMocks(this);
-		testDriver = new PersistentEntityTestDriver<>(system, new WeatherEntity(pubSubRegistry), entityId);
+		testDriver = new PersistentEntityTestDriver<>(system, new WeatherEntity(pubSubRegistryFacade), entityId);
 	}
 
 	@Test
@@ -112,18 +100,7 @@ class WeatherEntityTest {
 	}
 
 	@Test
-	@Disabled(
-			"Testing pubsub seems ludicrously difficult; currently not getting delivery of the " +
-			"message to DistributedPubSubMediator, but it seems to work fine in the actual " +
-			"service. PubSubRef is not mockable as it is final, so we need to subscribe for real."
-	)
 	void commandChangeEmitFrequency_PublishesStreamParameters() {
-		final PubSubRef<StreamParametersUpdated> pubSub = pubSubRegistry.refFor(
-				TopicId.of(StreamParametersUpdated.class, entityId)
-		);
-		final Probe<StreamParametersUpdated> probe = pubSub.subscriber().runWith(TestSink.probe(system), materializer);
-		probe.request(1);
-
 		final WeatherState initialState = testDriver.initialize(Optional.empty()).state();
 		final int frequency = 99;
 		final StreamParametersUpdated expectedMessage = StreamParametersUpdated.builder()
@@ -133,8 +110,11 @@ class WeatherEntityTest {
 
 		testDriver.run(new ChangeEmitFrequency(frequency));
 
-		final StreamParametersUpdated result = probe.expectNext(Duration.create(5, TimeUnit.SECONDS));
-		assertThat(result, is(expectedMessage));
+		verify(pubSubRegistryFacade).publish(
+				StreamParametersUpdated.class,
+				expectedMessage,
+				Optional.of(entityId)
+		);
 	}
 
 	@Test
@@ -164,6 +144,25 @@ class WeatherEntityTest {
 	}
 
 	@Test
+	void commandAddLocation_PublishesStreamParameters() {
+		final WeatherState initialState = testDriver.initialize(Optional.empty()).state();
+		final String location = "Somewhere Else, GB";
+		final StreamParametersUpdated expectedMessage = StreamParametersUpdated.builder()
+				.emitFrequencySecs(initialState.getEmitFrequencySecs())
+				.locations(initialState.getLocations())
+				.location(location)
+				.build();
+
+		testDriver.run(new AddLocation(location));
+
+		verify(pubSubRegistryFacade).publish(
+				StreamParametersUpdated.class,
+				expectedMessage,
+				Optional.of(entityId)
+		);
+	}
+
+	@Test
 	void commandRemoveLocation_LocationFound_PersistsEventAndUpdatesState_RepliesWithDone() {
 		final WeatherState initialState = testDriver.initialize(Optional.empty()).state();
 		final String location = initialState.getLocations().get(1);
@@ -189,7 +188,26 @@ class WeatherEntityTest {
 	}
 
 	@Test
-	void commandRemoveLocation_LocationNotFound_NoEventOrStateUpdate_RepliesWithDone() {
+	void commandRemoveLocation_LocationFound_PublishesStreamParameters() {
+		final WeatherState initialState = testDriver.initialize(Optional.empty()).state();
+		final List<String> locations = new ArrayList<>(initialState.getLocations());
+		final String location = locations.remove(locations.size() - 2);
+		final StreamParametersUpdated expectedMessage = StreamParametersUpdated.builder()
+				.emitFrequencySecs(initialState.getEmitFrequencySecs())
+				.locations(locations)
+				.build();
+
+		testDriver.run(new RemoveLocation(location));
+
+		verify(pubSubRegistryFacade).publish(
+				StreamParametersUpdated.class,
+				expectedMessage,
+				Optional.of(entityId)
+		);
+	}
+
+	@Test
+	void commandRemoveLocation_LocationNotFound_NoEventOrStateUpdateOrMessagePublished_RepliesWithDone() {
 		final WeatherState initialState = testDriver.initialize(Optional.empty()).state();
 		final String location = "Trumpsbrain, US";
 
@@ -200,6 +218,8 @@ class WeatherEntityTest {
 		assertThat(outcome.state(), is(initialState));
 		assertThat(outcome.getReplies(), hasSize(1));
 		assertThat((Done) outcome.getReplies().get(0), isA(Done.class));
+
+		verifyZeroInteractions(pubSubRegistryFacade);
 	}
 
 }

--- a/weather-service-impl/src/test/resources/application.conf
+++ b/weather-service-impl/src/test/resources/application.conf
@@ -7,6 +7,9 @@ db.default {
   url = "jdbc:h2:mem:weather"
 }
 
+# Need this for entity tests that use PubSub.
+akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
+
 akka.persistence {
   journal.plugin = "jdbc-journal"
   snapshot-store.plugin = "jdbc-snapshot-store"


### PR DESCRIPTION
Instead of firing off a command to our entity to fetch stream parameters every time we want to send a request to OWM (which could be as often as every 1 second), now we
- send an initial command to fetch stream parameters,
- subscribe to messages that the entity publishes whenever stream parameters change,
- rebuild the weather data source only when a message arrives.

This results in significantly less network traffic in a cluster. The only downsides are
- implementation code is more complex and a bit harder to understand;
- Lagom's PubSub is difficult to stub / mock / spy, so we need to use a facade similarly to the PersistentEntityRegistry facade.