### PR TITLE
Custom TransportException aware exception serializer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val `weather-service-api` = (project in file("weather-service-api"))
     common,
     libraryDependencies ++= commonApiDeps
   )
-  .dependsOn(`common-lib`)
+  .dependsOn(`common-lib`, `owm-adapter-api`)
 
 lazy val `weather-service-impl` = (project in file("weather-service-impl"))
   .enablePlugins(LagomJava)

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,10 @@ scalaVersion in ThisBuild := "2.12.6"
 
 lagomKafkaEnabled in ThisBuild := false
 
+// If tests run in parallel, Cassandra temp files cannot be deleted as the parallel thread has a
+// lock on these files and it seems that the main thread performs the teardown.
+parallelExecution in Test := false
+
 lazy val `weather-service` = (project in file("."))
   .aggregate(`weather-service-api`, `weather-service-impl`, `owm-adapter-api`, `owm-adapter-impl`)
 

--- a/owm-adapter-api/src/main/java/com/scottlogic/weather/owmadapter/api/message/Unauthorized.java
+++ b/owm-adapter-api/src/main/java/com/scottlogic/weather/owmadapter/api/message/Unauthorized.java
@@ -3,8 +3,8 @@ package com.scottlogic.weather.owmadapter.api.message;
 import com.lightbend.lagom.javadsl.api.transport.TransportErrorCode;
 import com.lightbend.lagom.javadsl.api.transport.TransportException;
 
-public class Unauthorized extends TransportException {
-	private static final TransportErrorCode ERROR_CODE = TransportErrorCode.fromHttp(401);
+public final class Unauthorized extends TransportException {
+	public static final TransportErrorCode ERROR_CODE = TransportErrorCode.fromHttp(401);
 
 	public Unauthorized(final String message) {
 		super(ERROR_CODE, message);

--- a/owm-adapter-impl/src/test/java/com/scottlogic/weather/owmadapter/impl/OwmAdapterTest.java
+++ b/owm-adapter-impl/src/test/java/com/scottlogic/weather/owmadapter/impl/OwmAdapterTest.java
@@ -36,6 +36,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+/**
+ * Note that we don't currently have an OWM test double, so we don't yet have integration tests for
+ * this service.
+ */
 @DisplayName("Tests for the OWM Adapter implementation")
 class OwmAdapterTest {
 	@Mock private OwmClient owmClient;

--- a/weather-service-api/src/main/java/com/scottlogic/weather/weatherservice/api/WeatherService.java
+++ b/weather-service-api/src/main/java/com/scottlogic/weather/weatherservice/api/WeatherService.java
@@ -11,6 +11,7 @@ import com.scottlogic.weather.weatherservice.api.message.CurrentWeatherResponse;
 import com.scottlogic.weather.weatherservice.api.message.SetEmitFrequencyRequest;
 import com.scottlogic.weather.weatherservice.api.message.WeatherForecastResponse;
 import com.scottlogic.weather.weatherservice.api.message.WeatherStreamParameters;
+import com.scottlogic.weather.weatherservice.api.serialization.CustomExceptionSerializer;
 
 import static com.lightbend.lagom.javadsl.api.Service.named;
 import static com.lightbend.lagom.javadsl.api.Service.restCall;
@@ -48,6 +49,7 @@ public interface WeatherService extends Service {
 						restCall(POST, "/api/weather-service/streaming/parameters/locations", this::addLocation),
 						restCall(DELETE, "/api/weather-service/streaming/parameters/locations/:location", this::removeLocation)
 				)
+				.withExceptionSerializer(CustomExceptionSerializer.getInstance())
 				.withAutoAcl(true);
 	}
 }

--- a/weather-service-api/src/main/java/com/scottlogic/weather/weatherservice/api/serialization/CustomExceptionSerializer.java
+++ b/weather-service-api/src/main/java/com/scottlogic/weather/weatherservice/api/serialization/CustomExceptionSerializer.java
@@ -1,0 +1,59 @@
+package com.scottlogic.weather.weatherservice.api.serialization;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.lightbend.lagom.javadsl.api.deser.RawExceptionMessage;
+import com.lightbend.lagom.javadsl.api.transport.TransportException;
+import com.lightbend.lagom.javadsl.jackson.JacksonExceptionSerializer;
+import com.scottlogic.weather.owmadapter.api.message.Unauthorized;
+import play.Environment;
+
+import java.util.Objects;
+
+@Singleton
+public class CustomExceptionSerializer extends JacksonExceptionSerializer {
+
+	private static CustomExceptionSerializer instance = null;
+
+	// Using static injection... Evil but (currently) necessary!
+	// Lagom currently provides no way to plug in an exception serializer that extends the default
+	// JacksonExceptionSerializer. The service descriptor takes an INSTANCE of an exception
+	// serializer rather than a CLASS, and therefore an exception serializer cannot be injected.
+	// Because we cannot make use of injection, we cannot use e.g. Config or any other injectable
+	// types in our exception serializer. JacksonExceptionSerializer injects Environment, so that
+	// it can tell whether or not the service is running in PROD, and thereby hide or expose details
+	// of exceptions. But this means that we cannot extend JacksonExceptionSerializer because we
+	// have no way to get hold of a correctly configured instance of Environment.
+	//
+	// There is an open issue in github for allowing injection of serializers:
+	// https://github.com/lagom/lagom/issues/1072
+	@Inject
+	private static Environment environment;
+
+	public static CustomExceptionSerializer getInstance() {
+		if (instance == null) {
+			instance = new CustomExceptionSerializer();
+		}
+		return instance;
+	}
+
+	@Override
+	public Throwable deserialize(final RawExceptionMessage message) {
+		final Throwable throwable = super.deserialize(message);
+
+		if (throwable instanceof TransportException && Objects.equals(
+				((TransportException) throwable).errorCode(),
+				Unauthorized.ERROR_CODE)
+		) {
+			return new Unauthorized(throwable.getMessage());
+		}
+
+		return throwable;
+	}
+
+	// Singleton class: use getInstance()
+	private CustomExceptionSerializer() {
+		super(environment);
+	}
+
+}

--- a/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/StreamGenerator.java
+++ b/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/StreamGenerator.java
@@ -206,6 +206,7 @@ public class StreamGenerator {
 			final Function<String, CompletionStage<T>> getWeatherFunction
 	) {
 		// OWM free tier only allows 60 API calls per minute, so throttle to one per second.
+		// In case OWM is slow, allow our own buffer of up to three concurrent requests.
 		return Source.cycle(locations::iterator)
 				.throttle(1, Duration.of(1, ChronoUnit.SECONDS))
 				.mapAsync(3, getWeatherFunction)

--- a/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/StreamGeneratorFactory.java
+++ b/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/StreamGeneratorFactory.java
@@ -17,7 +17,7 @@ public class StreamGeneratorFactory {
 	public StreamGeneratorFactory(
 			final OwmAdapter owmAdapter,
 			final PersistentEntityRegistryFacade persistentEntityRegistryFacade,
-			PubSubRegistryFacade pubSubRegistryFacade,
+			final PubSubRegistryFacade pubSubRegistryFacade,
 			final Materializer materializer
 	) {
 		this.owmAdapter = owmAdapter;

--- a/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/WeatherServiceImpl.java
+++ b/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/WeatherServiceImpl.java
@@ -37,7 +37,7 @@ public class WeatherServiceImpl implements WeatherService {
 	// No user sessions for now; just one entity:
 	private final String entityId = "default";
 
-	private final OwmAdapter owmAdapterService;
+	private final OwmAdapter owmAdapter;
 	private final StreamGeneratorFactory streamGeneratorFactory;
 	private final PersistentEntityRegistryFacade entityRegistryFacade;
 
@@ -47,7 +47,7 @@ public class WeatherServiceImpl implements WeatherService {
 			final StreamGeneratorFactory streamGeneratorFactory,
 			final PersistentEntityRegistryFacade entityRegistryFacade
 	) {
-		this.owmAdapterService = owmAdapter;
+		this.owmAdapter = owmAdapter;
 		this.streamGeneratorFactory = streamGeneratorFactory;
 		this.entityRegistryFacade = entityRegistryFacade;
 		this.entityRegistryFacade.register(WeatherEntity.class);
@@ -57,7 +57,7 @@ public class WeatherServiceImpl implements WeatherService {
 	public ServiceCall<NotUsed, CurrentWeatherResponse> currentWeather(final String location) {
 		return request -> {
 			log.info("Received request for current weather in [{}]", location);
-			return this.owmAdapterService.getCurrentWeather(location).invoke()
+			return this.owmAdapter.getCurrentWeather(location).invoke()
 					.thenApply(MessageUtils::weatherDataToCurrentWeatherResponse)
 					.thenApply(response -> {
 						log.info("Sending current weather for [{}]", response.getLocation());
@@ -71,8 +71,8 @@ public class WeatherServiceImpl implements WeatherService {
 		return request -> {
 			log.info("Received request for weather forecast for [{}]", location);
 
-			final CompletionStage<WeatherData> current = this.owmAdapterService.getCurrentWeather(location).invoke();
-			final CompletionStage<List<WeatherData>> forecast = this.owmAdapterService.getWeatherForecast(location).invoke();
+			final CompletionStage<WeatherData> current = this.owmAdapter.getCurrentWeather(location).invoke();
+			final CompletionStage<List<WeatherData>> forecast = this.owmAdapter.getWeatherForecast(location).invoke();
 
 			return current.thenCombine(forecast, MessageUtils::weatherDataToWeatherForecastResponse)
 					.thenApply(response -> {

--- a/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/WeatherServiceModule.java
+++ b/weather-service-impl/src/main/java/com/scottlogic/weather/weatherservice/impl/WeatherServiceModule.java
@@ -4,6 +4,7 @@ import com.google.inject.AbstractModule;
 import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport;
 import com.scottlogic.weather.owmadapter.api.OwmAdapter;
 import com.scottlogic.weather.weatherservice.api.WeatherService;
+import com.scottlogic.weather.weatherservice.api.serialization.CustomExceptionSerializer;
 
 /**
  * The module that binds the WeatherService so that it can be served.
@@ -14,5 +15,8 @@ public class WeatherServiceModule extends AbstractModule implements ServiceGuice
 	protected void configure() {
 		bindService(WeatherService.class, WeatherServiceImpl.class);
 		bindClient(OwmAdapter.class);
+
+		// Here be dragons! See comment in CustomExceptionSerializer.
+		requestStaticInjection(CustomExceptionSerializer.class);
 	}
 }

--- a/weather-service-impl/src/main/resources/application.conf
+++ b/weather-service-impl/src/main/resources/application.conf
@@ -5,6 +5,11 @@ cassandra-journal.keyspace = ${weather.cassandra.keyspace}
 cassandra-snapshot-store.keyspace = ${weather.cassandra.keyspace}
 lagom.persistence.read-side.cassandra.keyspace = ${weather.cassandra.keyspace}
 
+akka.persistence {
+  journal.plugins = "cassandra-journal"
+  snapshot-store.plugin = "cassandra-snapshot-store"
+}
+
 # Take control over serialization / deserialization features!
 lagom.serialization.json.jackson-modules += com.scottlogic.weather.common.serialization.CommonServiceJacksonModule
 

--- a/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/WeatherServiceIT.java
+++ b/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/WeatherServiceIT.java
@@ -1,0 +1,75 @@
+package com.scottlogic.weather.weatherservice.impl;
+
+import com.lightbend.lagom.javadsl.api.transport.TransportException;
+import com.lightbend.lagom.javadsl.testkit.ServiceTest.TestServer;
+import com.scottlogic.weather.owmadapter.api.OwmAdapter;
+import com.scottlogic.weather.owmadapter.api.message.Unauthorized;
+import com.scottlogic.weather.weatherservice.api.WeatherService;
+import com.scottlogic.weather.weatherservice.api.message.CurrentWeatherResponse;
+import com.scottlogic.weather.weatherservice.impl.stub.OwmAdapterStub;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static com.lightbend.lagom.javadsl.testkit.ServiceTest.bind;
+import static com.lightbend.lagom.javadsl.testkit.ServiceTest.defaultSetup;
+import static com.lightbend.lagom.javadsl.testkit.ServiceTest.startServer;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class WeatherServiceIT {
+
+	private static TestServer server;
+
+	private WeatherService weatherService;
+
+	@BeforeAll
+	static void beforeAll() {
+		server = startServer(defaultSetup()
+				.withCassandra()
+				.configureBuilder(b -> b.overrides(
+						bind(OwmAdapter.class).to(OwmAdapterStub.class),
+						bind(StreamGeneratorFactory.class).toSelf(),
+						bind(PersistentEntityRegistryFacade.class).toSelf()
+				))
+		);
+	}
+
+	@AfterAll
+	static void afterAll() {
+		if (server != null) {
+			server.stop();
+			server = null;
+		}
+
+	}
+
+	@Test
+	void currentWeather_ValidLocation_RespondsWithWeatherData() throws Exception {
+		final String location = "Stockholm, SE";
+		weatherService = server.client(WeatherService.class);
+
+		final CurrentWeatherResponse response = weatherService.currentWeather(location).invoke()
+				.toCompletableFuture().get(5, SECONDS);
+
+		assertThat(response.getLocation(), is(location));
+	}
+
+	@Test
+	void currentWeather_SimulateBadApiKey_ThrowsUnauthorized() {
+		weatherService = server.client(WeatherService.class);
+
+		final ExecutionException executionException = assertThrows(ExecutionException.class, () ->
+				weatherService.currentWeather(OwmAdapterStub.LOCATION_401).invoke().toCompletableFuture().get(5, SECONDS)
+		);
+
+		assertThat(((TransportException) executionException.getCause()).exceptionMessage().name(), is(Unauthorized.class.getSimpleName()));
+		// This only works because of static injection for our exception serializer ... Yikes!
+		assertThat(((Unauthorized) executionException.getCause()), isA(Unauthorized.class));
+	}
+}

--- a/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/WeatherServiceIT.java
+++ b/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/WeatherServiceIT.java
@@ -1,14 +1,17 @@
 package com.scottlogic.weather.weatherservice.impl;
 
+import com.lightbend.lagom.javadsl.api.transport.NotFound;
 import com.lightbend.lagom.javadsl.api.transport.TransportException;
 import com.lightbend.lagom.javadsl.testkit.ServiceTest.TestServer;
 import com.scottlogic.weather.owmadapter.api.OwmAdapter;
 import com.scottlogic.weather.owmadapter.api.message.Unauthorized;
 import com.scottlogic.weather.weatherservice.api.WeatherService;
 import com.scottlogic.weather.weatherservice.api.message.CurrentWeatherResponse;
+import com.scottlogic.weather.weatherservice.api.message.WeatherForecastResponse;
 import com.scottlogic.weather.weatherservice.impl.stub.OwmAdapterStub;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
@@ -18,6 +21,7 @@ import static com.lightbend.lagom.javadsl.testkit.ServiceTest.defaultSetup;
 import static com.lightbend.lagom.javadsl.testkit.ServiceTest.startServer;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -49,10 +53,14 @@ class WeatherServiceIT {
 
 	}
 
+	@BeforeEach
+	void beforeTest() {
+	    weatherService = server.client(WeatherService.class);
+	}
+
 	@Test
 	void currentWeather_ValidLocation_RespondsWithWeatherData() throws Exception {
 		final String location = "Stockholm, SE";
-		weatherService = server.client(WeatherService.class);
 
 		final CurrentWeatherResponse response = weatherService.currentWeather(location).invoke()
 				.toCompletableFuture().get(5, SECONDS);
@@ -62,14 +70,65 @@ class WeatherServiceIT {
 
 	@Test
 	void currentWeather_SimulateBadApiKey_ThrowsUnauthorized() {
-		weatherService = server.client(WeatherService.class);
-
 		final ExecutionException executionException = assertThrows(ExecutionException.class, () ->
-				weatherService.currentWeather(OwmAdapterStub.LOCATION_401).invoke().toCompletableFuture().get(5, SECONDS)
+				weatherService.currentWeather(OwmAdapterStub.LOCATION_401).invoke()
+						.toCompletableFuture().get(5, SECONDS)
 		);
 
-		assertThat(((TransportException) executionException.getCause()).exceptionMessage().name(), is(Unauthorized.class.getSimpleName()));
+		assertThat(
+				((TransportException) executionException.getCause()).exceptionMessage().name(),
+				is(Unauthorized.class.getSimpleName())
+		);
 		// This only works because of static injection for our exception serializer ... Yikes!
 		assertThat(((Unauthorized) executionException.getCause()), isA(Unauthorized.class));
 	}
+
+	@Test
+	void currentWeather_SimulateUnknownLocation_ThrowsNotFound() {
+	    final ExecutionException executionException = assertThrows(ExecutionException.class, () ->
+				weatherService.currentWeather(OwmAdapterStub.LOCATION_404).invoke()
+						.toCompletableFuture().get(5, SECONDS)
+		);
+
+	    assertThat(((NotFound) executionException.getCause()), isA(NotFound.class));
+	}
+
+	@Test
+	void weatherForecast_ValidLocation_RespondsWithWeatherData() throws Exception {
+	    final String location = "Nowhere, US";
+
+	    final WeatherForecastResponse response = weatherService.weatherForecast(location).invoke()
+			    .toCompletableFuture().get(5, SECONDS);
+
+		assertThat(response.getLocation(), is(location));
+		assertThat(response.getForecast(), hasSize(40));
+	}
+
+	@Test
+	void weatherForecast_SimulateBadApiKey_ThrowsUnauthorized() {
+		final ExecutionException executionException = assertThrows(ExecutionException.class, () ->
+				weatherService.weatherForecast(OwmAdapterStub.LOCATION_401).invoke()
+						.toCompletableFuture().get(5, SECONDS)
+		);
+
+		assertThat(
+				((TransportException) executionException.getCause()).exceptionMessage().name(),
+				is(Unauthorized.class.getSimpleName())
+		);
+		// This only works because of static injection for our exception serializer ... Yikes!
+		assertThat(((Unauthorized) executionException.getCause()), isA(Unauthorized.class));
+	}
+
+	@Test
+	void weatherForecast_SimulateUnknownLocation_ThrowsNotFound() {
+		final ExecutionException executionException = assertThrows(ExecutionException.class, () ->
+				weatherService.weatherForecast(OwmAdapterStub.LOCATION_404).invoke()
+						.toCompletableFuture().get(5, SECONDS)
+		);
+
+		assertThat(((NotFound) executionException.getCause()), isA(NotFound.class));
+	}
+
+	// For brevity, omitting stream tests which are together covered by WeatherServiceTest and
+	// StreamGeneratorTest; I intend to write standalone integration tests at a later date.
 }

--- a/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/entity/WeatherEntityTest.java
+++ b/weather-service-impl/src/test/java/com/scottlogic/weather/weatherservice/impl/entity/WeatherEntityTest.java
@@ -67,14 +67,14 @@ class WeatherEntityTest {
 	void commandGetWeatherStreamParameters_ReturnsValuesFromCurrentState() {
 		final WeatherState initialState = testDriver.initialize(Optional.empty()).state();
 
-		final Outcome<WeatherEvent, WeatherState> outcomeOne = testDriver.run(new GetWeatherStreamParameters());
-		assertThat(outcomeOne.issues(), is(empty()));
-		assertThat(outcomeOne.events(), is(empty()));
-		assertThat(outcomeOne.getReplies(), hasSize(1));
+		final Outcome<WeatherEvent, WeatherState> outcome = testDriver.run(new GetWeatherStreamParameters());
+		assertThat(outcome.issues(), is(empty()));
+		assertThat(outcome.events(), is(empty()));
+		assertThat(outcome.getReplies(), hasSize(1));
 
-		final WeatherStreamParameters replyOne = (WeatherStreamParameters) outcomeOne.getReplies().get(0);
-		assertThat(replyOne.getEmitFrequencySeconds(), is(initialState.getEmitFrequencySecs()));
-		assertThat(replyOne.getLocations(), is(initialState.getLocations()));
+		final WeatherStreamParameters reply = (WeatherStreamParameters) outcome.getReplies().get(0);
+		assertThat(reply.getEmitFrequencySeconds(), is(initialState.getEmitFrequencySecs()));
+		assertThat(reply.getLocations(), is(initialState.getLocations()));
 	}
 
 	@Test

--- a/weather-service-impl/src/test/resources/application.conf
+++ b/weather-service-impl/src/test/resources/application.conf
@@ -1,18 +1,19 @@
-# For some reason, using an embedded Cassandra instance does not work nicely on my machine as I get
-# filesystem access denied issues when the test run cleans up after itself; this leaves large temp
-# folders on the filesystem which I need to manually remove. In future I could provide an
-# alternative config file for running tests with Cassandra.
-db.default {
-  driver = "org.h2.Driver"
-  url = "jdbc:h2:mem:weather"
-}
-
 # Need this for entity tests that use PubSub.
 akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
 
-akka.persistence {
-  journal.plugin = "jdbc-journal"
-  snapshot-store.plugin = "jdbc-snapshot-store"
-}
-
-jdbc-defaults.slick.driver = "slick.driver.H2Driver$"
+# For some reason, using an embedded Cassandra instance does not work nicely on my machine as I get
+# filesystem access denied issues when the test run cleans up after itself; this leaves large temp
+# folders on the filesystem which I need to manually remove. In future I could provide an
+# alternative config file, so I could run tests with either Cassandra or H2.
+#
+#akka.persistence {
+#  journal.plugin = "jdbc-journal"
+#  snapshot-store.plugin = "jdbc-snapshot-store"
+#}
+#
+#db.default {
+#  driver = "org.h2.Driver"
+#  url = "jdbc:h2:mem:weather"
+#}
+#
+#jdbc-defaults.slick.driver = "slick.driver.H2Driver$"


### PR DESCRIPTION
Exception Deserialization (after an exception is serialized for sending over the network) does not work for custom exceptions that extend TransportException; they are deserialized as TransportException instead of the sub-type. This PR adds an exception (de)serializer which allows us to deserialize into our own TransportException subclasses.

Also reverted to using Cassandra in tests, and disabled parallel test execution as that was messing with embedded Cassandra teardown: temp files could not be deleted because the parallel thread had a lock on them when the main thread was trying to delete them. One option might be to spin up cassandra before all test suites, and tear it down after all, but am unsure if Lagom supports that. This is why a separate, standalone project for integration tests would be preferable.